### PR TITLE
[Entity] 상속용 BaseEntity 생성 및 리팩토링

### DIFF
--- a/src/main/java/com/soolsul/soolsulserver/domain/auth/Authority.java
+++ b/src/main/java/com/soolsul/soolsulserver/domain/auth/Authority.java
@@ -1,0 +1,13 @@
+package com.soolsul.soolsulserver.domain.auth;
+
+import org.springframework.security.core.GrantedAuthority;
+
+
+public class Authority implements GrantedAuthority {
+    private Role authority;
+
+    @Override
+    public String getAuthority() {
+        return authority.name();
+    }
+}

--- a/src/main/java/com/soolsul/soolsulserver/domain/auth/Authority.java
+++ b/src/main/java/com/soolsul/soolsulserver/domain/auth/Authority.java
@@ -10,4 +10,6 @@ public class Authority implements GrantedAuthority {
     public String getAuthority() {
         return authority.name();
     }
+
+    public Role getRole(){return authority;}
 }

--- a/src/main/java/com/soolsul/soolsulserver/domain/auth/Authority.java
+++ b/src/main/java/com/soolsul/soolsulserver/domain/auth/Authority.java
@@ -4,10 +4,13 @@ import com.soolsul.soolsulserver.domain.common.BaseEntity;
 import org.springframework.security.core.GrantedAuthority;
 
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 
 
 @Entity
 public class Authority extends BaseEntity implements GrantedAuthority {
+    @Enumerated(value = EnumType.STRING)
     private Role authority;
 
     @Override

--- a/src/main/java/com/soolsul/soolsulserver/domain/auth/Authority.java
+++ b/src/main/java/com/soolsul/soolsulserver/domain/auth/Authority.java
@@ -1,9 +1,13 @@
 package com.soolsul.soolsulserver.domain.auth;
 
+import com.soolsul.soolsulserver.domain.common.BaseEntity;
 import org.springframework.security.core.GrantedAuthority;
 
+import javax.persistence.Entity;
 
-public class Authority implements GrantedAuthority {
+
+@Entity
+public class Authority extends BaseEntity implements GrantedAuthority {
     private Role authority;
 
     @Override

--- a/src/main/java/com/soolsul/soolsulserver/domain/auth/RefreshToken.java
+++ b/src/main/java/com/soolsul/soolsulserver/domain/auth/RefreshToken.java
@@ -1,0 +1,14 @@
+package com.soolsul.soolsulserver.domain.auth;
+
+import com.soolsul.soolsulserver.domain.common.BaseTimeEntity;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Entity;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken extends BaseTimeEntity {
+    private String refreshToken;
+    private String userId;
+}

--- a/src/main/java/com/soolsul/soolsulserver/domain/auth/Role.java
+++ b/src/main/java/com/soolsul/soolsulserver/domain/auth/Role.java
@@ -1,0 +1,7 @@
+package com.soolsul.soolsulserver.domain.auth;
+
+public enum Role {
+    USER_ROLE,
+    ADMIN_ROLE,
+    GUEST_ROLE
+}

--- a/src/main/java/com/soolsul/soolsulserver/domain/auth/User.java
+++ b/src/main/java/com/soolsul/soolsulserver/domain/auth/User.java
@@ -26,7 +26,7 @@ public class User extends BaseTimeEntity implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return authorities.stream().map(userAuthority -> userAuthority.getAuthority()).toList();
+        return authorities.stream().map(UserAuthority::getGrantedAuthority).toList();
     }
 
     @Override

--- a/src/main/java/com/soolsul/soolsulserver/domain/auth/User.java
+++ b/src/main/java/com/soolsul/soolsulserver/domain/auth/User.java
@@ -1,0 +1,56 @@
+package com.soolsul.soolsulserver.domain.auth;
+
+import com.soolsul.soolsulserver.domain.common.BaseTimeEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseTimeEntity implements UserDetails {
+    private String email;
+    private String password;
+    @OneToMany(mappedBy = "user")
+    private List<UserAuthority> authorities = new ArrayList<>();
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities.stream().map(userAuthority -> userAuthority.getAuthority()).toList();
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/soolsul/soolsulserver/domain/auth/UserAuthority.java
+++ b/src/main/java/com/soolsul/soolsulserver/domain/auth/UserAuthority.java
@@ -8,13 +8,18 @@ import lombok.NoArgsConstructor;
 import javax.persistence.*;
 
 @Entity
-@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserAuthority extends BaseEntity {
     @JoinColumn(name = "user_id")
     @ManyToOne(fetch = FetchType.LAZY)
+    @Getter
     private User user;
 
-    @Enumerated
+    @Enumerated(value = EnumType.STRING)
     private Authority authority;
+    public Role getAuthority() {
+        return authority.getRole();
+    }
+
+
 }

--- a/src/main/java/com/soolsul/soolsulserver/domain/auth/UserAuthority.java
+++ b/src/main/java/com/soolsul/soolsulserver/domain/auth/UserAuthority.java
@@ -1,0 +1,20 @@
+package com.soolsul.soolsulserver.domain.auth;
+
+import com.soolsul.soolsulserver.domain.common.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserAuthority extends BaseEntity {
+    @JoinColumn(name = "user_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    @Enumerated
+    private Authority authority;
+}

--- a/src/main/java/com/soolsul/soolsulserver/domain/auth/UserAuthority.java
+++ b/src/main/java/com/soolsul/soolsulserver/domain/auth/UserAuthority.java
@@ -15,11 +15,15 @@ public class UserAuthority extends BaseEntity {
     @Getter
     private User user;
 
-    @Enumerated(value = EnumType.STRING)
+    @JoinColumn
+    @ManyToOne(fetch = FetchType.LAZY)
     private Authority authority;
     public Role getAuthority() {
         return authority.getRole();
     }
 
+    public Authority getGrantedAuthority() {
+        return authority;
+    }
 
 }

--- a/src/main/java/com/soolsul/soolsulserver/domain/common/BaseEntity.java
+++ b/src/main/java/com/soolsul/soolsulserver/domain/common/BaseEntity.java
@@ -1,4 +1,24 @@
 package com.soolsul.soolsulserver.domain.common;
 
-public class BaseEntity {
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.GenericGenerator;
+
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.MappedSuperclass;
+
+@MappedSuperclass
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class BaseEntity {
+    @Id
+    @GeneratedValue(generator = "uuid")
+    @GenericGenerator(name = "uuid", strategy = "uuid")
+    private String id;
+
+    protected BaseEntity(String id) {
+        this.id = id;
+    }
 }

--- a/src/main/java/com/soolsul/soolsulserver/domain/common/BaseTimeEntity.java
+++ b/src/main/java/com/soolsul/soolsulserver/domain/common/BaseTimeEntity.java
@@ -1,19 +1,29 @@
 package com.soolsul.soolsulserver.domain.common;
 
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
 
 @Getter
 @MappedSuperclass
-public abstract class BaseTimeEntity {
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class BaseTimeEntity extends BaseEntity{
 
     @CreatedDate
     private LocalDateTime createdAt;
 
     @LastModifiedDate
     private LocalDateTime updateAt;
+
+    protected BaseTimeEntity(String id) {
+        super(id);
+    }
 }

--- a/src/main/java/com/soolsul/soolsulserver/domain/common/Category.java
+++ b/src/main/java/com/soolsul/soolsulserver/domain/common/Category.java
@@ -1,0 +1,18 @@
+package com.soolsul.soolsulserver.domain.common;
+
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.MappedSuperclass;
+
+@MappedSuperclass
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class Category extends BaseTimeEntity{
+    private String name;
+}

--- a/src/main/java/com/soolsul/soolsulserver/domain/common/Duration.java
+++ b/src/main/java/com/soolsul/soolsulserver/domain/common/Duration.java
@@ -1,0 +1,16 @@
+package com.soolsul.soolsulserver.domain.common;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Embeddable;
+import java.time.LocalDateTime;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Duration {
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+}

--- a/src/main/java/com/soolsul/soolsulserver/domain/common/OwnerEntity.java
+++ b/src/main/java/com/soolsul/soolsulserver/domain/common/OwnerEntity.java
@@ -1,0 +1,25 @@
+package com.soolsul.soolsulserver.domain.common;
+
+
+import com.soolsul.soolsulserver.domain.auth.User;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.EntityListeners;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.MappedSuperclass;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class OwnerEntity extends BaseTimeEntity{
+    @CreatedBy
+    @JoinColumn(name = "owner_id")
+    @ManyToOne
+    private User owner;
+}

--- a/src/main/java/com/soolsul/soolsulserver/domain/curation/Curation.java
+++ b/src/main/java/com/soolsul/soolsulserver/domain/curation/Curation.java
@@ -13,11 +13,6 @@ import javax.persistence.Id;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Curation extends BaseTimeEntity {
 
-    @Id
-    @GeneratedValue(generator = "uuid")
-    @GenericGenerator(name = "uuid", strategy = "uuid")
-    private String id;
-
     private String title;
 
     private String mainPictureUrl;
@@ -25,6 +20,5 @@ public class Curation extends BaseTimeEntity {
     private String content;
 
     private String restaurantId;
-
 }
 

--- a/src/main/java/com/soolsul/soolsulserver/domain/curation/CurationPicture.java
+++ b/src/main/java/com/soolsul/soolsulserver/domain/curation/CurationPicture.java
@@ -1,5 +1,6 @@
 package com.soolsul.soolsulserver.domain.curation;
 
+import com.soolsul.soolsulserver.domain.common.OwnerEntity;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.GenericGenerator;
@@ -10,7 +11,7 @@ import javax.persistence.Id;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class CurationPicture {
+public class CurationPicture extends OwnerEntity {
 
     @Id
     @GeneratedValue(generator = "uuid")

--- a/src/main/java/com/soolsul/soolsulserver/domain/menu/Alcohol.java
+++ b/src/main/java/com/soolsul/soolsulserver/domain/menu/Alcohol.java
@@ -1,5 +1,6 @@
 package com.soolsul.soolsulserver.domain.menu;
 
+import com.soolsul.soolsulserver.domain.common.BaseTimeEntity;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.GenericGenerator;
@@ -10,13 +11,7 @@ import javax.persistence.Id;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Alcohol {
-
-    @Id
-    @GeneratedValue(generator = "uuid")
-    @GenericGenerator(name = "uuid", strategy = "uuid")
-    private Long id;
-
+public class Alcohol extends BaseTimeEntity {
     private String name;
 
     private int alcoholPercent;

--- a/src/main/java/com/soolsul/soolsulserver/domain/menu/AlcoholCategory.java
+++ b/src/main/java/com/soolsul/soolsulserver/domain/menu/AlcoholCategory.java
@@ -1,5 +1,6 @@
 package com.soolsul.soolsulserver.domain.menu;
 
+import com.soolsul.soolsulserver.domain.common.Category;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.GenericGenerator;
@@ -10,13 +11,4 @@ import javax.persistence.Id;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class AlcoholCategory {
-
-    @Id
-    @GeneratedValue(generator = "uuid")
-    @GenericGenerator(name = "uuid", strategy = "uuid")
-    private Long id;
-
-    private String name;
-
-}
+public class AlcoholCategory extends Category { }

--- a/src/main/java/com/soolsul/soolsulserver/domain/menu/Snack.java
+++ b/src/main/java/com/soolsul/soolsulserver/domain/menu/Snack.java
@@ -1,5 +1,6 @@
 package com.soolsul.soolsulserver.domain.menu;
 
+import com.soolsul.soolsulserver.domain.common.BaseTimeEntity;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.GenericGenerator;
@@ -10,15 +11,7 @@ import javax.persistence.Id;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Snack {
-
-    @Id
-    @GeneratedValue(generator = "uuid")
-    @GenericGenerator(name = "uuid", strategy = "uuid")
-    private Long id;
-
+public class Snack extends BaseTimeEntity {
     private String name;
-
     private Long snackCategoryId;
-
 }

--- a/src/main/java/com/soolsul/soolsulserver/domain/menu/SnackCategory.java
+++ b/src/main/java/com/soolsul/soolsulserver/domain/menu/SnackCategory.java
@@ -1,5 +1,6 @@
 package com.soolsul.soolsulserver.domain.menu;
 
+import com.soolsul.soolsulserver.domain.common.Category;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.GenericGenerator;
@@ -10,13 +11,4 @@ import javax.persistence.Id;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class SnackCategory {
-
-    @Id
-    @GeneratedValue(generator = "uuid")
-    @GenericGenerator(name = "uuid", strategy = "uuid")
-    private Long id;
-
-    private String name;
-
-}
+public class SnackCategory extends Category {}

--- a/src/main/java/com/soolsul/soolsulserver/domain/menu/SnackMenu.java
+++ b/src/main/java/com/soolsul/soolsulserver/domain/menu/SnackMenu.java
@@ -12,16 +12,7 @@ import javax.persistence.Id;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SnackMenu extends BaseTimeEntity {
-
-    @Id
-    @GeneratedValue(generator = "uuid")
-    @GenericGenerator(name = "uuid", strategy = "uuid")
-    private String id;
-
-    private double cost;
-
+    private Long cost;
     private String snackId;
-
     private String restaurantId;
-
 }

--- a/src/main/java/com/soolsul/soolsulserver/domain/region/Location.java
+++ b/src/main/java/com/soolsul/soolsulserver/domain/region/Location.java
@@ -11,11 +11,8 @@ import javax.persistence.Embeddable;
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Location {
-
     @Column(nullable = false)
     private double latitude;
-
     @Column(nullable = false)
     private double longitude;
-
 }

--- a/src/main/java/com/soolsul/soolsulserver/domain/region/Region.java
+++ b/src/main/java/com/soolsul/soolsulserver/domain/region/Region.java
@@ -1,5 +1,6 @@
 package com.soolsul.soolsulserver.domain.region;
 
+import com.soolsul.soolsulserver.domain.common.BaseEntity;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.GenericGenerator;
@@ -12,21 +13,11 @@ import javax.persistence.Id;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Region {
-
-    @Id
-    @GeneratedValue(generator = "uuid")
-    @GenericGenerator(name = "uuid", strategy = "uuid")
-    private String id;
-
+public class Region extends BaseEntity {
     @Column(nullable = false, length = 50)
     private String name;
-
     @Embedded
     private Location location;
-
-    private int depth;
-
+    private Integer depth;
     private String parentId;
-
 }

--- a/src/main/java/com/soolsul/soolsulserver/domain/restaurant/Restaurant.java
+++ b/src/main/java/com/soolsul/soolsulserver/domain/restaurant/Restaurant.java
@@ -1,5 +1,7 @@
 package com.soolsul.soolsulserver.domain.restaurant;
 
+import com.soolsul.soolsulserver.domain.common.BaseTimeEntity;
+import com.soolsul.soolsulserver.domain.region.Location;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.GenericGenerator;
@@ -11,18 +13,9 @@ import javax.persistence.Id;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Restaurant {
-
-    @Id
-    @GeneratedValue(generator = "uuid")
-    @GenericGenerator(name = "uuid", strategy = "uuid")
-    private String id;
-
+public class Restaurant extends BaseTimeEntity {
     @Embedded
     private Location location;
-
     private String regionId;
-
     private String restaurantCategoryId;
-
 }

--- a/src/main/java/com/soolsul/soolsulserver/domain/restaurant/RestaurantBookmark.java
+++ b/src/main/java/com/soolsul/soolsulserver/domain/restaurant/RestaurantBookmark.java
@@ -12,13 +12,6 @@ import javax.persistence.Id;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RestaurantBookmark extends BaseTimeEntity {
-
-    @Id
-    @GeneratedValue(generator = "uuid")
-    @GenericGenerator(name = "uuid", strategy = "uuid")
-    private String id;
-
     private String userInfoId;
     private String restaurantId;
-
 }

--- a/src/main/java/com/soolsul/soolsulserver/domain/restaurant/RestaurantOpenTime.java
+++ b/src/main/java/com/soolsul/soolsulserver/domain/restaurant/RestaurantOpenTime.java
@@ -1,9 +1,12 @@
 package com.soolsul.soolsulserver.domain.restaurant;
 
+import com.soolsul.soolsulserver.domain.common.BaseTimeEntity;
+import com.soolsul.soolsulserver.domain.common.Duration;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.GenericGenerator;
 
+import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
@@ -11,15 +14,8 @@ import java.time.LocalDateTime;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class RestaurantOpenTime {
-
-    @Id
-    @GeneratedValue(generator = "uuid")
-    @GenericGenerator(name = "uuid", strategy = "uuid")
-    private String id;
-
-    private LocalDateTime startTime;
-
-    private LocalDateTime endTime;
-
+public class RestaurantOpenTime extends BaseTimeEntity {
+    private String restaurantId;
+    @Embedded
+    private Duration duration;
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,11 +1,12 @@
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306?sample
-    username: root
-    password: 1234
+    url: jdbc:mysql://database-1.cbg3kx2zb4pv.ap-northeast-2.rds.amazonaws.com:3306/soolsul-dev
+    username: admin
+    password: soolsul661899!
+    driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: create
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
상속용 BaseEntity, OwnerEntity를 정의하고
다른 엔티티들에게서 빠진 롬복들을 점검하여 수정했습니다.
또한 상속을 통해 중복 컬럼을 제거했습니다.

Security 설정을 위한 엔티티들을 정의했습니다.
