### PR TITLE
[Feat-#39] 큐레이션 목록 조회

### DIFF
--- a/src/main/java/com/soolsul/soolsulserver/common/response/BaseResponse.java
+++ b/src/main/java/com/soolsul/soolsulserver/common/response/BaseResponse.java
@@ -18,5 +18,6 @@ public class BaseResponse<T> {
         this.message = message;
         this.data = data;
     }
+
 }
 

--- a/src/main/java/com/soolsul/soolsulserver/common/response/ResponseCodeAndMessages.java
+++ b/src/main/java/com/soolsul/soolsulserver/common/response/ResponseCodeAndMessages.java
@@ -1,19 +1,25 @@
 package com.soolsul.soolsulserver.common.response;
 
 public enum ResponseCodeAndMessages {
+    /* USER */
     USER_CREATE_SUCCESS("U001", "유저 생성에 성공했습니다."),
     USER_LOGIN_SUCCESS("U002", "로그인에 성공했습니다."),
     USER_UNAUTHENTICATED("U004", "해당 유저는 인증되지 않았습니다."),
     USER_UNAUTHORIZED("U005", "해당 유저는 권한이 없습니다."),
     USER_LOOK_UP_SUCCESS("U006", "해당 유저 정보를 찾는데 성공했습니다."),
 
+    /* FEED */
     FEED_CREATE_SUCCESS("P001", "피드 생성 성공했습니다."),
     FEED_FIND_SUCCESS("P002", "피드 찾기에 성공하였습니다."),
     // POO2 : update
     // POO3 : delete
     FEED_FIND_ALL_SUCCESS("P004", "모든 피드를 찾는데 성공하였습니다."),
 
-    BAR_LOOK_UP_SUCCESS("B001", "술집 목록 조회에 성공하였습니다.");
+    /* BAR */
+    BAR_LOOK_UP_SUCCESS("B001", "술집 목록 조회에 성공하였습니다."),
+
+    /* CURATION */
+    CURATIONS_LOOK_UP_SUCCESS("C001", "큐레이션 목록 조회에 성공하였습니다.");
 
 
     private final String code;
@@ -31,4 +37,5 @@ public enum ResponseCodeAndMessages {
     public String getMessage() {
         return message;
     }
+
 }

--- a/src/main/java/com/soolsul/soolsulserver/curation/business/CurationQueryService.java
+++ b/src/main/java/com/soolsul/soolsulserver/curation/business/CurationQueryService.java
@@ -1,0 +1,58 @@
+package com.soolsul.soolsulserver.curation.business;
+
+import com.soolsul.soolsulserver.curation.dto.CurationLookupResponse;
+import com.soolsul.soolsulserver.curation.persistence.CurationQueryRepository;
+import com.soolsul.soolsulserver.location.response.LocationSquareRangeCondition;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class CurationQueryService {
+
+    private final CurationQueryRepository curationQueryRepository;
+
+    public List<CurationLookupResponse> findAllSingleTagCurationsByLocationRange(
+            LocationSquareRangeCondition locationSquareRangeCondition
+    ) {
+        List<CurationLookupResponse> curationLookupResponses
+                = curationQueryRepository.findAllSingleTagCurationsByLocationRange(locationSquareRangeCondition);
+
+        Map<String, Boolean> curationIdMap = createCurationIdMap(curationLookupResponses);
+        return getFilteredSingleTagCuration(curationLookupResponses, curationIdMap);
+    }
+
+    private List<CurationLookupResponse> getFilteredSingleTagCuration(
+            List<CurationLookupResponse> curationLookupResponses,
+            Map<String, Boolean> curationIdMap
+    ) {
+        List<CurationLookupResponse> filteredSingleTagNameCurations = new ArrayList<>();
+
+        for (CurationLookupResponse curationLookupResponse : curationLookupResponses) {
+            String curationId = curationLookupResponse.curationId();
+            Boolean alreadyAddedCuration = curationIdMap.get(curationId);
+
+            if(!alreadyAddedCuration) {
+                filteredSingleTagNameCurations.add(curationLookupResponse);
+                curationIdMap.put(curationId, true);
+            }
+        }
+
+        return filteredSingleTagNameCurations;
+    }
+
+    // createCurationIdMap : 단일 태그 큐레이션을 추가하기 위한 함수 (key : curationId, Boolean : curation 추가 여부를 확인하는 변수)
+    private Map<String, Boolean> createCurationIdMap(List<CurationLookupResponse> curationLookupResponses) {
+        Map<String, Boolean> curationIdMap = new HashMap<>();
+        for (CurationLookupResponse curationLookupResponse : curationLookupResponses) {
+            curationIdMap.putIfAbsent(curationLookupResponse.curationId(), false);
+        }
+        return curationIdMap;
+    }
+
+}

--- a/src/main/java/com/soolsul/soolsulserver/curation/business/CurationQueryService.java
+++ b/src/main/java/com/soolsul/soolsulserver/curation/business/CurationQueryService.java
@@ -5,6 +5,7 @@ import com.soolsul.soolsulserver.curation.persistence.CurationQueryRepository;
 import com.soolsul.soolsulserver.location.response.LocationSquareRangeCondition;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -13,6 +14,7 @@ import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class CurationQueryService {
 
     private final CurationQueryRepository curationQueryRepository;

--- a/src/main/java/com/soolsul/soolsulserver/curation/business/CurationQueryService.java
+++ b/src/main/java/com/soolsul/soolsulserver/curation/business/CurationQueryService.java
@@ -21,7 +21,7 @@ public class CurationQueryService {
             LocationSquareRangeCondition locationSquareRangeCondition
     ) {
         List<CurationLookupResponse> curationLookupResponses
-                = curationQueryRepository.findAllSingleTagCurationsByLocationRange(locationSquareRangeCondition);
+                = curationQueryRepository.findAllCurationsInLocationRange(locationSquareRangeCondition);
 
         Map<String, Boolean> curationIdMap = createCurationIdMap(curationLookupResponses);
         return getFilteredSingleTagCuration(curationLookupResponses, curationIdMap);

--- a/src/main/java/com/soolsul/soolsulserver/curation/domain/Curation.java
+++ b/src/main/java/com/soolsul/soolsulserver/curation/domain/Curation.java
@@ -27,6 +27,13 @@ public class Curation extends BaseTimeEntity {
 
     private String barId;
 
+    public Curation(String title, String mainPictureUrl, String content, String barId) {
+        this.title = title;
+        this.mainPictureUrl = mainPictureUrl;
+        this.content = content;
+        this.barId = barId;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/com/soolsul/soolsulserver/curation/dto/CurationLookupResponse.java
+++ b/src/main/java/com/soolsul/soolsulserver/curation/dto/CurationLookupResponse.java
@@ -1,4 +1,11 @@
 package com.soolsul.soolsulserver.curation.dto;
 
-public record CurationLookupResponse() {
+public record CurationLookupResponse(
+        String curationId,
+        String mainPictureUrl,
+        String title,
+        String content,
+        String barMoodTagName,
+        String barAlcoholTagName
+) {
 }

--- a/src/main/java/com/soolsul/soolsulserver/curation/dto/CurationLookupResponse.java
+++ b/src/main/java/com/soolsul/soolsulserver/curation/dto/CurationLookupResponse.java
@@ -1,0 +1,4 @@
+package com.soolsul.soolsulserver.curation.dto;
+
+public record CurationLookupResponse() {
+}

--- a/src/main/java/com/soolsul/soolsulserver/curation/dto/CurationsLookupResponse.java
+++ b/src/main/java/com/soolsul/soolsulserver/curation/dto/CurationsLookupResponse.java
@@ -1,0 +1,8 @@
+package com.soolsul.soolsulserver.curation.dto;
+
+import java.util.List;
+
+public record CurationsLookupResponse(
+        List<CurationLookupResponse> curationLookupResponses
+) {
+}

--- a/src/main/java/com/soolsul/soolsulserver/curation/facade/CurationQueryFacade.java
+++ b/src/main/java/com/soolsul/soolsulserver/curation/facade/CurationQueryFacade.java
@@ -1,0 +1,17 @@
+package com.soolsul.soolsulserver.curation.facade;
+
+import com.soolsul.soolsulserver.curation.dto.CurationsLookupResponse;
+import com.soolsul.soolsulserver.location.request.LocationSquareRangeRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CurationQueryFacade {
+
+
+
+    public CurationsLookupResponse findAllCurationsByLocationRange(LocationSquareRangeRequest locationSquareRangeRequest) {
+        return null;
+    }
+}

--- a/src/main/java/com/soolsul/soolsulserver/curation/facade/CurationQueryFacade.java
+++ b/src/main/java/com/soolsul/soolsulserver/curation/facade/CurationQueryFacade.java
@@ -1,17 +1,31 @@
 package com.soolsul.soolsulserver.curation.facade;
 
+import com.soolsul.soolsulserver.curation.business.CurationQueryService;
+import com.soolsul.soolsulserver.curation.dto.CurationLookupResponse;
 import com.soolsul.soolsulserver.curation.dto.CurationsLookupResponse;
 import com.soolsul.soolsulserver.location.request.LocationSquareRangeRequest;
+import com.soolsul.soolsulserver.location.response.LocationSquareRangeCondition;
+import com.soolsul.soolsulserver.location.service.LocationRangeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
 public class CurationQueryFacade {
 
-
+    private final LocationRangeService locationRangeService;
+    private final CurationQueryService curationQueryService;
 
     public CurationsLookupResponse findAllCurationsByLocationRange(LocationSquareRangeRequest locationSquareRangeRequest) {
-        return null;
+        LocationSquareRangeCondition locationSquareRangeCondition = locationRangeService.calculateLocationSquareRange(
+                locationSquareRangeRequest);
+
+        List<CurationLookupResponse> singleTagCurationLookupResponses
+                = curationQueryService.findAllSingleTagCurationsByLocationRange(locationSquareRangeCondition);
+
+        return new CurationsLookupResponse(singleTagCurationLookupResponses);
     }
+
 }

--- a/src/main/java/com/soolsul/soolsulserver/curation/facade/CurationQueryFacade.java
+++ b/src/main/java/com/soolsul/soolsulserver/curation/facade/CurationQueryFacade.java
@@ -8,11 +8,13 @@ import com.soolsul.soolsulserver.location.response.LocationSquareRangeCondition;
 import com.soolsul.soolsulserver.location.service.LocationRangeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Component
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class CurationQueryFacade {
 
     private final LocationRangeService locationRangeService;

--- a/src/main/java/com/soolsul/soolsulserver/curation/persistence/CurationQueryRepository.java
+++ b/src/main/java/com/soolsul/soolsulserver/curation/persistence/CurationQueryRepository.java
@@ -1,0 +1,51 @@
+package com.soolsul.soolsulserver.curation.persistence;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.soolsul.soolsulserver.curation.dto.CurationLookupResponse;
+import com.soolsul.soolsulserver.location.response.LocationSquareRangeCondition;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.soolsul.soolsulserver.bar.domain.QBar.bar;
+import static com.soolsul.soolsulserver.bar.domain.QBarAlcoholTag.barAlcoholTag;
+import static com.soolsul.soolsulserver.bar.domain.QBarMoodTag.barMoodTag;
+import static com.soolsul.soolsulserver.curation.domain.QCuration.curation;
+
+@Repository
+@RequiredArgsConstructor
+public class CurationQueryRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    // 무드, 술집 태그 중복한 큐레이션 결과 반환
+    public List<CurationLookupResponse> findAllCurationsInLocationRange(
+            LocationSquareRangeCondition locationSquareRangeCondition
+    ) {
+        double southWestLatitude = locationSquareRangeCondition.southWestLatitude();
+        double southWestLongitude = locationSquareRangeCondition.southWestLongitude();
+        double northEastLatitude = locationSquareRangeCondition.northEastLatitude();
+        double northEastLongitude = locationSquareRangeCondition.northEastLongitude();
+
+        return jpaQueryFactory.select(Projections.constructor(
+                        CurationLookupResponse.class,
+                        curation.id,
+                        curation.mainPictureUrl,
+                        curation.title,
+                        curation.content,
+                        barMoodTag.name,
+                        barAlcoholTag.alcoholCategoryName))
+                .from(bar)
+                .innerJoin(curation).on(bar.id.eq(curation.barId))
+                .innerJoin(barMoodTag).on(bar.id.eq(barMoodTag.barId))
+                .innerJoin(barAlcoholTag).on(bar.id.eq(barAlcoholTag.barId))
+                .where(
+                        bar.location.latitude.between(southWestLatitude, northEastLatitude),
+                        bar.location.longitude.between(southWestLongitude, northEastLongitude)
+                )
+                .fetch();
+    }
+
+}

--- a/src/main/java/com/soolsul/soolsulserver/curation/presentation/CurationQueryController.java
+++ b/src/main/java/com/soolsul/soolsulserver/curation/presentation/CurationQueryController.java
@@ -1,0 +1,44 @@
+package com.soolsul.soolsulserver.curation.presentation;
+
+import com.soolsul.soolsulserver.common.response.BaseResponse;
+import com.soolsul.soolsulserver.common.response.ResponseCodeAndMessages;
+import com.soolsul.soolsulserver.curation.dto.CurationsLookupResponse;
+import com.soolsul.soolsulserver.curation.facade.CurationQueryFacade;
+import com.soolsul.soolsulserver.location.request.LocationSquareRangeRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.constraints.NotEmpty;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/curations")
+public class CurationQueryController {
+
+    private final CurationQueryFacade curationQueryFacade;
+
+    @GetMapping
+    public ResponseEntity<BaseResponse<CurationsLookupResponse>> findAllCurationsByLocationRange(
+            @RequestParam @NotEmpty double latitude, // 위도 (Y)
+            @RequestParam @NotEmpty double longitude, // 경도 (X)
+            @RequestParam(defaultValue = "3") int level
+    ) {
+        LocationSquareRangeRequest locationSquareRangeRequest = new LocationSquareRangeRequest(latitude, longitude, level);
+
+        CurationsLookupResponse curationsLookupResponse = curationQueryFacade.findAllCurationsByLocationRange(
+                locationSquareRangeRequest
+        );
+
+        BaseResponse<CurationsLookupResponse> baseResponse = new BaseResponse<>(
+                ResponseCodeAndMessages.CURATIONS_LOOK_UP_SUCCESS,
+                curationsLookupResponse
+        );
+
+        return ResponseEntity.ok(baseResponse);
+    }
+
+}

--- a/src/test/java/com/soolsul/soolsulserver/curation/business/CurationQueryServiceTest.java
+++ b/src/test/java/com/soolsul/soolsulserver/curation/business/CurationQueryServiceTest.java
@@ -36,7 +36,7 @@ class CurationQueryServiceTest {
         //given
         List<CurationLookupResponse> curationLookupResponses = initCurationLookupResponses();
 
-        given(curationQueryRepository.findAllSingleTagCurationsByLocationRange(any())).willReturn(curationLookupResponses);
+        given(curationQueryRepository.findAllCurationsInLocationRange(any())).willReturn(curationLookupResponses);
 
         //when
         List<CurationLookupResponse> SingleTagCurationLookupResponses

--- a/src/test/java/com/soolsul/soolsulserver/curation/business/CurationQueryServiceTest.java
+++ b/src/test/java/com/soolsul/soolsulserver/curation/business/CurationQueryServiceTest.java
@@ -1,0 +1,69 @@
+package com.soolsul.soolsulserver.curation.business;
+
+import com.soolsul.soolsulserver.curation.dto.CurationLookupResponse;
+import com.soolsul.soolsulserver.curation.persistence.CurationQueryRepository;
+import com.soolsul.soolsulserver.location.response.LocationSquareRangeCondition;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class CurationQueryServiceTest {
+
+    private CurationQueryService curationQueryService;
+
+    @Mock
+    private CurationQueryRepository curationQueryRepository;
+
+    @BeforeEach
+    void init() {
+        this.curationQueryService = new CurationQueryService(curationQueryRepository);
+    }
+
+    @DisplayName("단일 무드, 술 태그를 조회하는 로직을 조회한다")
+    @Test
+    void find_all_curations_by_locationRange() {
+        //given
+        List<CurationLookupResponse> curationLookupResponses = initCurationLookupResponses();
+
+        given(curationQueryRepository.findAllSingleTagCurationsByLocationRange(any())).willReturn(curationLookupResponses);
+
+        //when
+        List<CurationLookupResponse> SingleTagCurationLookupResponses
+                = curationQueryService.findAllSingleTagCurationsByLocationRange(new LocationSquareRangeCondition(0, 0, 0, 0));
+
+        //then
+        assertThat(SingleTagCurationLookupResponses).hasSize(2);
+    }
+
+    private List<CurationLookupResponse> initCurationLookupResponses() {
+        List<CurationLookupResponse> curationLookupResponses =new ArrayList<>();
+
+        curationLookupResponses.add(new CurationLookupResponse("c01", "url", "title", "content", "mood1", "alcohol1"));
+        curationLookupResponses.add(new CurationLookupResponse("c01", "url", "title", "content", "mood2", "alcohol1"));
+        curationLookupResponses.add(new CurationLookupResponse("c01", "url", "title", "content", "mood3", "alcohol1"));
+        curationLookupResponses.add(new CurationLookupResponse("c01", "url", "title", "content", "mood1", "alcohol1"));
+        curationLookupResponses.add(new CurationLookupResponse("c01", "url", "title", "content", "mood2", "alcohol2"));
+        curationLookupResponses.add(new CurationLookupResponse("c01", "url", "title", "content", "mood3", "alcohol3"));
+
+        curationLookupResponses.add(new CurationLookupResponse("c02", "url", "title", "content", "mood1", "alcohol1"));
+        curationLookupResponses.add(new CurationLookupResponse("c02", "url", "title", "content", "mood2", "alcohol1"));
+        curationLookupResponses.add(new CurationLookupResponse("c02", "url", "title", "content", "mood3", "alcohol1"));
+        curationLookupResponses.add(new CurationLookupResponse("c02", "url", "title", "content", "mood1", "alcohol1"));
+        curationLookupResponses.add(new CurationLookupResponse("c02", "url", "title", "content", "mood2", "alcohol2"));
+        curationLookupResponses.add(new CurationLookupResponse("c02", "url", "title", "content", "mood3", "alcohol3"));
+
+        return curationLookupResponses;
+    }
+
+}

--- a/src/test/java/com/soolsul/soolsulserver/curation/persistence/CurationQueryRepositoryTest.java
+++ b/src/test/java/com/soolsul/soolsulserver/curation/persistence/CurationQueryRepositoryTest.java
@@ -53,7 +53,7 @@ class CurationQueryRepositoryTest {
         );
 
         //then
-        assertThat(curationLookupResponses).hasSize(100);
+        assertThat(curationLookupResponses).hasSize(8);
     }
 
     private void initData() {

--- a/src/test/java/com/soolsul/soolsulserver/curation/persistence/CurationQueryRepositoryTest.java
+++ b/src/test/java/com/soolsul/soolsulserver/curation/persistence/CurationQueryRepositoryTest.java
@@ -1,0 +1,97 @@
+package com.soolsul.soolsulserver.curation.persistence;
+
+import com.soolsul.soolsulserver.bar.domain.Bar;
+import com.soolsul.soolsulserver.bar.domain.BarAlcoholTag;
+import com.soolsul.soolsulserver.bar.domain.BarMoodTag;
+import com.soolsul.soolsulserver.config.QueryDslConfig;
+import com.soolsul.soolsulserver.curation.domain.Curation;
+import com.soolsul.soolsulserver.curation.dto.CurationLookupResponse;
+import com.soolsul.soolsulserver.location.response.LocationSquareRangeCondition;
+import com.soolsul.soolsulserver.region.domain.Location;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Import(QueryDslConfig.class)
+@DataJpaTest(
+        includeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = CurationQueryRepository.class)
+)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class CurationQueryRepositoryTest {
+
+    @Autowired
+    private CurationQueryRepository curationQueryRepository;
+
+    @Autowired
+    private TestEntityManager testEntityManager;
+
+    @BeforeEach
+    void init() {
+        initData();
+    }
+
+    @DisplayName("경위도와 요청 범위 내에 큐레이션 정보를 조회한다(술집, 무드 중복 큐레이션 반환)")
+    @Test
+    void find_all_curations_in_location_range() {
+        //given
+        LocationSquareRangeCondition locationSquareRangeCondition = new LocationSquareRangeCondition(119, 29, 122, 32);
+
+        //when
+        List<CurationLookupResponse> curationLookupResponses = curationQueryRepository.findAllCurationsInLocationRange(
+                locationSquareRangeCondition
+        );
+
+        //then
+        assertThat(curationLookupResponses).hasSize(100);
+    }
+
+    private void initData() {
+        //Bar data
+        Bar bar01 = new Bar("region1", "category1", "name1", "description", new Location(120, 30));
+        Bar bar02 = new Bar("region2", "category2", "name2", "description", new Location(121, 31));
+
+        testEntityManager.persist(bar01);
+        testEntityManager.persist(bar02);
+
+        //Curation data
+        Curation curation01 = new Curation("curationTitle1", "mainUrl1", "curationContent1", bar01.getId());
+        Curation curation02 = new Curation("curationTitle2", "mainUrl2", "curationContent2", bar02.getId());
+
+        testEntityManager.persist(curation01);
+        testEntityManager.persist(curation02);
+
+        //BarMoodTag data
+        BarMoodTag barMoodTag01 = new BarMoodTag(bar01.getId(), "mood1", "moodName1", true, 0);
+        BarMoodTag barMoodTag02 = new BarMoodTag(bar01.getId(), "mood2", "moodName2", true, 0);
+        BarMoodTag barMoodTag03 = new BarMoodTag(bar02.getId(), "mood1", "moodName1", true, 0);
+        BarMoodTag barMoodTag04 = new BarMoodTag(bar02.getId(), "mood2", "moodName2", true, 0);
+
+        testEntityManager.persist(barMoodTag01);
+        testEntityManager.persist(barMoodTag02);
+        testEntityManager.persist(barMoodTag03);
+        testEntityManager.persist(barMoodTag04);
+
+        //BarAlcoholTag data
+        BarAlcoholTag barAlcoholTag01 = new BarAlcoholTag(bar01.getId(), "alcoholCategoryId1", "alcoholCategoryName1");
+        BarAlcoholTag barAlcoholTag02 = new BarAlcoholTag(bar01.getId(), "alcoholCategoryId2", "alcoholCategoryName2");
+        BarAlcoholTag barAlcoholTag03 = new BarAlcoholTag(bar02.getId(), "alcoholCategoryId1", "alcoholCategoryName1");
+        BarAlcoholTag barAlcoholTag04 = new BarAlcoholTag(bar02.getId(), "alcoholCategoryId2", "alcoholCategoryName2");
+
+        testEntityManager.persist(barAlcoholTag01);
+        testEntityManager.persist(barAlcoholTag02);
+        testEntityManager.persist(barAlcoholTag03);
+        testEntityManager.persist(barAlcoholTag04);
+    }
+
+}

--- a/src/test/java/com/soolsul/soolsulserver/curation/presentation/CurationQueryControllerTest.java
+++ b/src/test/java/com/soolsul/soolsulserver/curation/presentation/CurationQueryControllerTest.java
@@ -1,0 +1,62 @@
+package com.soolsul.soolsulserver.curation.presentation;
+
+import com.soolsul.soolsulserver.curation.dto.CurationsLookupResponse;
+import com.soolsul.soolsulserver.curation.facade.CurationQueryFacade;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.security.config.annotation.web.WebSecurityConfigurer;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.ArrayList;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(value = CurationQueryController.class,
+        excludeFilters = {@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, value = WebSecurityConfigurer.class)}, //security 설정을 종료하기 위한 설정
+        excludeAutoConfiguration = SecurityAutoConfiguration.class //security auto configuration 을 종료하기 위한 설정
+)
+class CurationQueryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private CurationQueryFacade curationQueryFacade;
+
+    @DisplayName("큐레이션 목록 조회 요청에 관한 응답을 확인한다")
+    @Test
+    void find_all_curations_by_location_range() throws Exception {
+        //given
+        double latitude = 37.0;
+        double longitude = 126.12;
+
+        given(curationQueryFacade.findAllCurationsByLocationRange(any()))
+                .willReturn(new CurationsLookupResponse(new ArrayList<>()));
+
+        //when
+        ResultActions result = mockMvc.perform(get("/api/curations")
+                .param("latitude", String.valueOf(latitude))
+                .param("longitude", String.valueOf(longitude)));
+
+        //then
+        result.andExpectAll(
+                status().isOk(),
+                jsonPath("$.code").value("C001"),
+                jsonPath("$.message").isNotEmpty(),
+                jsonPath("$.data").isNotEmpty()
+        );
+
+    }
+
+}


### PR DESCRIPTION
- CurationQueryRepository에서 무드, 술 태그를 허용하고 CurationQueryService 에서 단일 무드, 술태그 필터링하는 로직으로 처리했습니다!
- 페이지네이션이 필요한 경우 추가 로직 수정이 필요합니다.
- 빌드 및 테스트 통과 합니다~