### PR TITLE
[refactor-#84] Authentication 제거 리팩토링

### DIFF
--- a/src/main/java/com/soolsul/soolsulserver/post/presentation/PostController.java
+++ b/src/main/java/com/soolsul/soolsulserver/post/presentation/PostController.java
@@ -1,5 +1,6 @@
 package com.soolsul.soolsulserver.post.presentation;
 
+import com.soolsul.soolsulserver.user.auth.CurrentUser;
 import com.soolsul.soolsulserver.user.auth.CustomUser;
 import com.soolsul.soolsulserver.common.response.BaseResponse;
 import com.soolsul.soolsulserver.common.response.ResponseCodeAndMessages;
@@ -13,7 +14,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -32,16 +32,20 @@ public class PostController {
     private final PostFacadeGateway postFacadeGateway;
 
     @PostMapping
-    public ResponseEntity<BaseResponse<Void>> createPost(@Valid @RequestBody PostCreateRequest request, Authentication authentication) {
-        CustomUser customUser = (CustomUser) authentication.getPrincipal();
-        postFacadeGateway.create(customUser.getId(), request);
+    public ResponseEntity<BaseResponse<Void>> createPost(
+            @Valid @RequestBody PostCreateRequest request,
+            @CurrentUser CustomUser currentUser
+    ) {
+        postFacadeGateway.create(currentUser.getId(), request);
         return ResponseEntity.ok(new BaseResponse<>(ResponseCodeAndMessages.FEED_CREATE_SUCCESS, null));
     }
 
     @GetMapping("/{postId}")
-    public ResponseEntity<BaseResponse<PostDetailResponse>> findDetailPost(@PathVariable String postId, Authentication authentication) {
-        CustomUser customUser = (CustomUser) authentication.getPrincipal();
-        PostDetailResponse postDetailResponse = postFacadeGateway.find(customUser.getId(), postId);
+    public ResponseEntity<BaseResponse<PostDetailResponse>> findDetailPost(
+            @PathVariable String postId,
+            @CurrentUser CustomUser currentUser
+    ) {
+        PostDetailResponse postDetailResponse = postFacadeGateway.find(currentUser.getId(), postId);
         return ResponseEntity.ok(new BaseResponse<>(ResponseCodeAndMessages.FEED_FIND_SUCCESS, postDetailResponse));
     }
 
@@ -51,18 +55,19 @@ public class PostController {
             @RequestParam double longitude,
             @RequestParam(defaultValue = "3") int level,
             @PageableDefault(size = 6) Pageable pageable,
-            Authentication authentication
+            @CurrentUser CustomUser currentUser
     ) {
-        CustomUser customUser = (CustomUser) authentication.getPrincipal();
         LocationSquareRangeRequest locationSquareRangeRequest = new LocationSquareRangeRequest(latitude, longitude, level);
-        PostListResponse postListResponse = postFacadeGateway.findAll(customUser.getId(), locationSquareRangeRequest, pageable);
+        PostListResponse postListResponse = postFacadeGateway.findAll(currentUser.getId(), locationSquareRangeRequest, pageable);
         return ResponseEntity.ok(new BaseResponse<>(ResponseCodeAndMessages.FEED_FIND_ALL_SUCCESS, postListResponse));
     }
 
     @PostMapping("/scraps")
-    public ResponseEntity<BaseResponse<Void>> scrapPost(@Valid @RequestBody PostScrapRequest request, Authentication authentication) {
-        CustomUser customUser = (CustomUser) authentication.getPrincipal();
-        postFacadeGateway.scrap(customUser.getId(), request.postId());
+    public ResponseEntity<BaseResponse<Void>> scrapPost(
+            @Valid @RequestBody PostScrapRequest request,
+            @CurrentUser CustomUser currentUser
+    ) {
+        postFacadeGateway.scrap(currentUser.getId(), request.postId());
         return ResponseEntity.ok(new BaseResponse<>(ResponseCodeAndMessages.FEED_SCRAP_SUCCESS, null));
     }
 }

--- a/src/main/java/com/soolsul/soolsulserver/user/auth/CurrentUser.java
+++ b/src/main/java/com/soolsul/soolsulserver/user/auth/CurrentUser.java
@@ -1,0 +1,14 @@
+package com.soolsul.soolsulserver.user.auth;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@AuthenticationPrincipal
+public @interface CurrentUser {
+}

--- a/src/main/java/com/soolsul/soolsulserver/user/mypage/presentation/MyPageController.java
+++ b/src/main/java/com/soolsul/soolsulserver/user/mypage/presentation/MyPageController.java
@@ -2,6 +2,7 @@ package com.soolsul.soolsulserver.user.mypage.presentation;
 
 import com.soolsul.soolsulserver.common.response.BaseResponse;
 import com.soolsul.soolsulserver.common.response.ResponseCodeAndMessages;
+import com.soolsul.soolsulserver.user.auth.CurrentUser;
 import com.soolsul.soolsulserver.user.mypage.presentation.dto.response.ScrapedPostListLookUpResponse;
 import com.soolsul.soolsulserver.user.auth.CustomUser;
 import com.soolsul.soolsulserver.user.auth.repository.dto.UserLookUpResponse;
@@ -23,17 +24,15 @@ public class MyPageController {
     private final MyPageQueryFacade myPageQueryFacade;
 
     @GetMapping("/me")
-    public ResponseEntity<BaseResponse<UserLookUpResponse>> searchUser(Authentication authentication) {
-        CustomUser user = (CustomUser) authentication.getPrincipal();
-        UserLookUpResponse userLookUpResponse = myPageQueryFacade.findUserWithDetailInfo(user.getId());
+    public ResponseEntity<BaseResponse<UserLookUpResponse>> searchUser(@CurrentUser CustomUser currentUser) {
+        UserLookUpResponse userLookUpResponse = myPageQueryFacade.findUserWithDetailInfo(currentUser.getId());
         return ResponseEntity.ok(new BaseResponse<>(USER_LOOK_UP_SUCCESS, userLookUpResponse));
     }
 
 
     @GetMapping("/scraps")
-    public ResponseEntity<BaseResponse<ScrapedPostListLookUpResponse>> findAllScrapedPost(Authentication authentication) {
-        CustomUser user = (CustomUser) authentication.getPrincipal();
-        ScrapedPostListLookUpResponse scrapedPostListResponse = myPageQueryFacade.findAllScrapedPost(user.getId());
+    public ResponseEntity<BaseResponse<ScrapedPostListLookUpResponse>> findAllScrapedPost(@CurrentUser CustomUser currentUser) {
+        ScrapedPostListLookUpResponse scrapedPostListResponse = myPageQueryFacade.findAllScrapedPost(currentUser.getId());
         return ResponseEntity.ok(new BaseResponse<>(ResponseCodeAndMessages.FEED_FIND_ALL_SCRAP_SUCCESS, scrapedPostListResponse));
     }
 }


### PR DESCRIPTION
### 작업 내용 공유
1. @AuthenticationPrincipal 을 사용하면 SecurityContextHolder 에 있는 Principal 객체를 가지고 올 수 있다고 합니다
   (단순히 파라미터로 Principal 을 추가하면 사용자의 입력 정보가 넘어와서 null이 넘어왔었던 것 같아요)
2. 추가적으로 `@AuthenticationPrincipal` 커스텀 어노테이션인 `@CurrentUser` 커스텀 어노테이션 추가해서 작업 진행했습니다! 앞으로 해당 어노테이션으로 유저 정보 추가하면 될 것 같아요!
3. 학습용으로 정리했던 내용 공유합니다~ 혹시 추가적으로 수정할 내용있으면 말씀해주세요
   - https://dune-store-e37.notion.site/zum-tech-CMS-3e8e9fdcfa5a4fe1a7562ec71affd2dd
